### PR TITLE
Disable historical_weather()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bomrang
 Type: Package
 Title: Australian Government Bureau of Meteorology ('BOM') Data Client
-Version: 0.7.4.9000
+Version: 0.7.4.9001
 Authors@R:
     c(person(given = "Adam H.",
              family = "Sparks",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # bomrang (development version)
 
+# bomrang 0.7.5
+
+* `get_historical_weather()` has been disabled due to changes by BOM. See https://github.com/ropensci/bomrang/discussions/141
+
 # bomrang 0.7.4
 
 ## Bug fixes

--- a/R/get_historical_weather.R
+++ b/R/get_historical_weather.R
@@ -87,7 +87,8 @@
 #' @author Jonathan Carroll, \email{rpkg@@jcarroll.com.au}
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
+#' ## these are currently not functional due to BOM changes
 #' get_historical_weather(stationid = "023000",
 #'                       type = "max") ## ~48,000+ daily records
 #' get_historical_weather(latlon = c(-35.2809, 149.1300),
@@ -101,6 +102,12 @@ get_historical_weather <- get_historical <-
            latlon = NULL,
            radius = NULL,
            type = c("rain", "min", "max", "solar")) {
+
+    stop("Due to recent changes by the BOM, this functionality is temporarily disabled. 
+    Refer to http://reg.bom.gov.au/other/copyright.shtml
+    and
+    https://github.com/ropensci/bomrang/discussions/141")
+
     site <- ncc_obs_code <- NULL #nocov
     
     if (is.null(stationid) & is.null(latlon))


### PR DESCRIPTION
Disables `get_historical_weather()` with a reference to the BOM site and the discussion page.
* Tests all contain `skip_on_cran()` anyway, and these still pass
```
withr::with_envvar(c(NOT_CRAN = "false"), devtools::test()) 
── Skipped tests  ─────────────────
● On CRAN (92)

[ FAIL 0 | WARN 0 | SKIP 92 | PASS 5 ]
```
* Changed example to wrapped in `\dontrun{}`